### PR TITLE
Change userdata to absolute path instead of relative

### DIFF
--- a/grid-app/proxy/manager.go
+++ b/grid-app/proxy/manager.go
@@ -547,7 +547,7 @@ func main() {
 			fmt.Println(err)
 		}
 
-		dirName := "userdata/workspace-" + uuidFromUrl
+		dirName := "/home/userdata/workspace-" + uuidFromUrl
 
 		if _, err := os.Stat(dirName); !os.IsNotExist(err) {
 			removeCommand := "rm -rf " + dirName
@@ -580,7 +580,7 @@ func main() {
 
 			var dirName string
 
-			dirName = "userdata/workspace-" + uuidFromUrl
+			dirName = "/home/userdata/workspace-" + uuidFromUrl
 
 			fmt.Println(dirName)
 
@@ -590,7 +590,7 @@ func main() {
 				requestingUser := getUser(r, db)
 
 				newUuid := uuid.NewV4().String()
-				newDirName := "userdata/workspace-" + newUuid
+				newDirName := "/home/userdata/workspace-" + newUuid
 
 				// get name form DB
 				rows, err := db.Query("SELECT name, shared, owner FROM workspaces WHERE slug = ? LIMIT 1", uuidFromUrl)
@@ -664,7 +664,7 @@ func main() {
 
 		var dirName string
 
-		dirName = "userdata/workspace-" + uuidString
+		dirName = "/home/userdata/workspace-" + uuidString
 
 		user := getUser(r, db)
 


### PR DESCRIPTION
While deploying on GKE I realized that the `userfolder` wasn't being created in the right filepath. I changed it to use absolute paths to fix this issue.

As a side note: the root access, file permissions such as chmod of 777 can likely be improved by creating a user with limited access (even inside the container).