### PR TITLE
Add sponsor button to project

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: gridstudio


### PR DESCRIPTION
It's probably worth adding your patreon link directly to the top of the project with a GitHub sponsorship button. You can see how this appears visually in [my fork](https://github.com/montudor/gridstudio).

After merging, you will have to enable the [sponsorship button](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository) in your [repository settings](https://github.com/ricklamers/gridstudio/settings).

I was going to add your PayPal link as a custom link in the `FUNDING.yml` file, however, it appears your link is currently broken for me, so I left it.