### PR TITLE
Fix: on windows docker build error

### DIFF
--- a/grid-app/Dockerfile
+++ b/grid-app/Dockerfile
@@ -12,7 +12,8 @@ wget \
 python3-pip \
 locales \
 curl \
-git
+git \
+python3-distutils
 
 # # TODO: see if any locale issues arise
 # # RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \


### PR DESCRIPTION
on windows it will complain ModuleNotFoundError: No module named 'distutils.util'